### PR TITLE
allow complex schur decomposition

### DIFF
--- a/src/atomate2/forcefields/md.py
+++ b/src/atomate2/forcefields/md.py
@@ -272,8 +272,8 @@ class ForceFieldMDMaker(Maker):
         if md_func is NPT:
             # Note that until md_func is instantiated, isinstance(md_func,NPT) is False
             # ASE NPT implementation requires upper triangular cell
-            u, _ = schur(atoms.get_cell(complete=True))
-            atoms.set_cell(u, scale_atoms=True)
+            u, _ = schur(atoms.get_cell(complete=True), output="complex")
+            atoms.set_cell(u.real, scale_atoms=True)
 
         if initial_velocities:
             atoms.set_velocities(initial_velocities)


### PR DESCRIPTION
Allow complex number decomposition for schur. The reason for this is some cell shapes cannot have strictly upper-triangular T for  A = Z T Z^H ([details](https://docs.scipy.org/doc/scipy/reference/generated/scipy.linalg.schur.html))

```python
u, _ = schur(atoms.get_cell(complete=True), output="complex")
atoms.set_cell(u.real, scale_atoms=True)


```
