### PR TITLE
Memory overload fix and more metadata

### DIFF
--- a/src/atomate2/ase/jobs.py
+++ b/src/atomate2/ase/jobs.py
@@ -16,7 +16,7 @@ from atomate2.ase.utils import AseRelaxer
 
 logger = logging.getLogger(__name__)
 
-_ASE_DATA_OBJECTS = [PmgTrajectory, AseTrajectory]
+_ASE_DATA_OBJECTS = [PmgTrajectory, AseTrajectory, "ionic_steps"]
 
 if TYPE_CHECKING:
     from pathlib import Path

--- a/src/atomate2/ase/md.py
+++ b/src/atomate2/ase/md.py
@@ -374,7 +374,7 @@ class AseMDMaker(Maker):
             final_mol_or_struct=mol_or_struct,
             trajectory=md_observer.to_pymatgen_trajectory(filename=None),
             dir_name=os.getcwd(),
-            run_time=t_f - t_i,
+            elapsed_time=t_f - t_i,
         )
 
     @property

--- a/src/atomate2/ase/md.py
+++ b/src/atomate2/ase/md.py
@@ -6,6 +6,7 @@ import contextlib
 import io
 import os
 import sys
+import time
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from enum import Enum
@@ -355,7 +356,9 @@ class AseMDMaker(Maker):
 
         md_runner.attach(_callback, interval=1)
         with contextlib.redirect_stdout(sys.stdout if self.verbose else io.StringIO()):
+            t_i = time.perf_counter()
             md_runner.run(steps=self.n_steps)
+            t_f = time.perf_counter()
 
         if self.traj_file is not None:
             md_observer.save(filename=self.traj_file, fmt=self.traj_file_fmt)
@@ -371,6 +374,7 @@ class AseMDMaker(Maker):
             final_mol_or_struct=mol_or_struct,
             trajectory=md_observer.to_pymatgen_trajectory(filename=None),
             dir_name=os.getcwd(),
+            run_time=t_f - t_i,
         )
 
     @property

--- a/src/atomate2/ase/schemas.py
+++ b/src/atomate2/ase/schemas.py
@@ -67,6 +67,10 @@ class AseResult(BaseModel):
         None, description="The directory where the calculation was run"
     )
 
+    elapsed_time: Optional[float] = Field(
+        None, description="The time taken to run the calculation."
+    )
+
     def __getitem__(self, name: str) -> Any:
         """Make fields subscriptable for backwards compatibility."""
         return getattr(self, name)
@@ -325,6 +329,8 @@ class AseTaskDoc(AseBaseModel):
             "is less than in the initial frame."
         ),
     )
+
+    tags: Optional[list[str]] = Field(None, description="List of tags for the task.")
 
     @classmethod
     def from_ase_compatible_result(

--- a/src/atomate2/ase/schemas.py
+++ b/src/atomate2/ase/schemas.py
@@ -433,9 +433,11 @@ class AseTaskDoc(AseBaseModel):
         ionic_steps = []
         for idx in range(n_steps):
             _ionic_step_data = {
-                key: trajectory.frame_properties[idx].get(key)
-                if key in ionic_step_data
-                else None
+                key: (
+                    trajectory.frame_properties[idx].get(key)
+                    if key in ionic_step_data
+                    else None
+                )
                 for key in ("energy", "forces", "stress")
             }
 
@@ -447,9 +449,11 @@ class AseTaskDoc(AseBaseModel):
             if "magmoms" in trajectory.frame_properties[idx]:
                 _ionic_step_data.update(
                     {
-                        "magmoms": trajectory.frame_properties[idx]["magmoms"]
-                        if "magmoms" in ionic_step_data
-                        else None
+                        "magmoms": (
+                            trajectory.frame_properties[idx]["magmoms"]
+                            if "magmoms" in ionic_step_data
+                            else None
+                        )
                     }
                 )
 

--- a/src/atomate2/ase/schemas.py
+++ b/src/atomate2/ase/schemas.py
@@ -33,6 +33,7 @@ _task_doc_translation_keys = {
     "objects",
     "is_force_converged",
     "energy_downhill",
+    "tags",
 }
 
 
@@ -227,6 +228,8 @@ class AseStructureTaskDoc(StructureMetadata):
         ),
     )
 
+    tags: Optional[list[str]] = Field(None, description="List of tags for the task.")
+
     @classmethod
     def from_ase_task_doc(
         cls, ase_task_doc: AseTaskDoc, **task_document_kwargs
@@ -289,6 +292,8 @@ class AseMoleculeTaskDoc(MoleculeMetadata):
             "is less than in the initial frame."
         ),
     )
+
+    tags: Optional[list[str]] = Field(None, description="List of tags for the task.")
 
 
 class AseTaskDoc(AseBaseModel):

--- a/src/atomate2/ase/schemas.py
+++ b/src/atomate2/ase/schemas.py
@@ -147,6 +147,8 @@ class OutputDoc(AseBaseModel):
         None, description="Step-by-step trajectory of the relaxation."
     )
 
+    elapsed_time: Optional[float] = Field("The time taken to run the calculation.")
+
     n_steps: int = Field(
         None, description="total number of steps needed in the relaxation."
     )
@@ -473,6 +475,7 @@ class AseTaskDoc(AseBaseModel):
             forces=final_forces,
             stress=final_stress,
             ionic_steps=ionic_steps,
+            elapsed_time=result.elapsed_time,
             n_steps=n_steps,
         )
 

--- a/src/atomate2/ase/utils.py
+++ b/src/atomate2/ase/utils.py
@@ -6,6 +6,7 @@ import contextlib
 import io
 import os
 import sys
+import time
 import warnings
 from typing import TYPE_CHECKING
 
@@ -385,7 +386,9 @@ class AseRelaxer:
                 atoms = cell_filter(atoms)
             optimizer = self.opt_class(atoms, **kwargs)
             optimizer.attach(obs, interval=interval)
+            t_i = time.perf_counter()
             optimizer.run(fmax=fmax, steps=steps)
+            t_f = time.perf_counter()
             obs()
         if traj_file is not None:
             obs.save(traj_file)
@@ -407,4 +410,5 @@ class AseRelaxer:
             energy_downhill=traj.frame_properties[-1]["energy"]
             < traj.frame_properties[0]["energy"],
             dir_name=os.getcwd(),
+            elapsed_time=t_f - t_i,
         )

--- a/src/atomate2/forcefields/jobs.py
+++ b/src/atomate2/forcefields/jobs.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-_FORCEFIELD_DATA_OBJECTS = [PmgTrajectory, AseTrajectory]
+_FORCEFIELD_DATA_OBJECTS = [PmgTrajectory, AseTrajectory, "ionic_steps"]
 
 
 def forcefield_job(method: Callable) -> job:

--- a/tests/ase/test_md.py
+++ b/tests/ase/test_md.py
@@ -38,12 +38,14 @@ def test_ase_nvt_maker(calculator_name, lj_fcc_ne_pars, fcc_ne_structure):
         temperature=1000,
         ensemble="nvt",
         n_steps=100,
+        task_document_kwargs={"tags": ["test"], "store_trajectory": "partial"},
     ).make(fcc_ne_structure)
 
     response = run_locally(md_job)
     output = response[md_job.uuid][1].output
 
     assert isinstance(output, AseStructureTaskDoc)
+    assert output.tags == ["test"]
     assert output.output.energy_per_atom == pytest.approx(
         reference_energies[calculator_name]
     )

--- a/tests/ase/test_utils.py
+++ b/tests/ase/test_utils.py
@@ -123,11 +123,15 @@ def test_relaxer(si_structure, test_dir, tmp_dir, optimizer, traj_file):
     )
 
     assert_allclose(
-        relax_output.trajectory.frame_properties[-1]["forces"], expected_forces
+        relax_output["trajectory"].frame_properties[-1]["forces"],
+        expected_forces,
+        atol=1e-11,
     )
 
     assert_allclose(
-        relax_output.trajectory.frame_properties[-1]["stress"], expected_stresses
+        relax_output["trajectory"].frame_properties[-1]["stress"],
+        expected_stresses,
+        atol=1e-11,
     )
 
     if traj_file:


### PR DESCRIPTION
In addition to taking a stab at fixing the memory issue, I added some metadata that I'd love to have included. Let me know what you think @esoteric-ephemera.

## Summary

Include a summary of major changes in bullet points:

* Add "ionic_steps" into `DATA_OBJECTS` so it doesn't surpass MongoDB 16 MB limit
* Add timing to ASE runs
* Add `tags` to task document, can be provided through `task_document_kwargs`

## Questions

Is `task_document_kwargs` around to maintain backwards compability? It seems like it only supports 3-4 kwargs so I wonder if it'd be easier to just list them explicitly. It's hard to know what arguments are available through it or where they will be used.

## Checklist

Work-in-progress pull requests are encouraged, but please put [WIP] in the pull request
title.

Before a pull request can be merged, the following items must be checked:

* [x] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/).
  The easiest way to handle this is to run the following in the **correct sequence** on
  your local machine. Start with running [`ruff`](https://docs.astral.sh/ruff) and `ruff format` on your new code. This will
  automatically reformat your code to PEP8 conventions and fix many linting issues.
* [x] Doc strings have been added in the [Numpy docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html).
  Run [ruff](https://beta.ruff.rs/docs/rules/#pydocstyle-d) on your code.
* [x] Type annotations are **highly** encouraged. Run [mypy](http://mypy-lang.org) to
  type check your code.
* [x] Tests have been added for any new functionality or bug fixes.
* [ ] All linting and tests pass.

Note that the CI system will run all the above checks. But it will be much more
efficient if you already fix most errors prior to submitting the PR. It is highly
recommended that you use the pre-commit hook provided in the repository. Simply run
`pre-commit install` and a check will be run prior to allowing commits.
