### PR TITLE
Fix silent error when running NotImplemented functions

### DIFF
--- a/src/atomate2/ase/jobs.py
+++ b/src/atomate2/ase/jobs.py
@@ -89,12 +89,12 @@ class AseMaker(Maker):
             A previous calculation directory to copy output files from. Unused, just
                 added to match the method signature of other makers.
         """
-        return NotImplemented
+        raise NotImplementedError
 
     @property
     def calculator(self) -> Calculator:
         """ASE calculator, method to be implemented in subclasses."""
-        return NotImplemented
+        raise NotImplementedError
 
 
 @dataclass

--- a/src/atomate2/ase/md.py
+++ b/src/atomate2/ase/md.py
@@ -383,7 +383,7 @@ class AseMDMaker(AseMaker):
     @property
     def calculator(self) -> Calculator:
         """ASE calculator, to be overwritten by user."""
-        return NotImplemented
+        raise NotImplementedError
 
 
 @dataclass

--- a/src/atomate2/forcefields/utils.py
+++ b/src/atomate2/forcefields/utils.py
@@ -42,8 +42,15 @@ def ase_calculator(calculator_meta: str | dict, **kwargs: Any) -> Calculator | N
     """
     calculator = None
 
-    if isinstance(calculator_meta, str) and calculator_meta in map(str, MLFF):
-        calculator_name = MLFF(calculator_meta.split("MLFF.")[-1])
+    if isinstance(calculator_meta, str):
+        valid_calculators = [name.split("MLFF.")[-1] for name in map(str, MLFF)]
+
+        if "MLFF." in calculator_meta:
+            calculator_name = MLFF(calculator_meta.split("MLFF.")[-1])
+        elif calculator_meta in valid_calculators:
+            calculator_name = MLFF(calculator_meta)
+        else:
+            raise ValueError(f"Could not create calculator from {calculator_meta}.")
 
         if calculator_name == MLFF.CHGNet:
             from chgnet.model.dynamics import CHGNetCalculator

--- a/src/atomate2/forcefields/utils.py
+++ b/src/atomate2/forcefields/utils.py
@@ -42,15 +42,8 @@ def ase_calculator(calculator_meta: str | dict, **kwargs: Any) -> Calculator | N
     """
     calculator = None
 
-    if isinstance(calculator_meta, str):
-        valid_calculators = [name.split("MLFF.")[-1] for name in map(str, MLFF)]
-
-        if "MLFF." in calculator_meta:
-            calculator_name = MLFF(calculator_meta.split("MLFF.")[-1])
-        elif calculator_meta in valid_calculators:
-            calculator_name = MLFF(calculator_meta)
-        else:
-            raise ValueError(f"Could not create calculator from {calculator_meta}.")
+    if isinstance(calculator_meta, str) and calculator_meta in map(str, MLFF):
+        calculator_name = MLFF(calculator_meta.split("MLFF.")[-1])
 
         if calculator_name == MLFF.CHGNet:
             from chgnet.model.dynamics import CHGNetCalculator
@@ -93,6 +86,9 @@ def ase_calculator(calculator_meta: str | dict, **kwargs: Any) -> Calculator | N
     elif isinstance(calculator_meta, dict):
         calc_cls = MontyDecoder().decode(json.dumps(calculator_meta))
         calculator = calc_cls(**kwargs)
+
+    if calculator is None:
+        raise ValueError("Could not create ASE calculator.")
 
     return calculator
 

--- a/tests/forcefields/test_utils.py
+++ b/tests/forcefields/test_utils.py
@@ -17,6 +17,18 @@ def test_ext_load(force_field: str):
     assert calc_from_decode.parameters == calc_from_preset.parameters == {}
 
 
+def test_raises_error():
+    with pytest.raises(ValueError, match="Could not create"):
+        ase_calculator("not_a_calculator")
+
+
+@pytest.mark.parametrize(("force_field"), ["CHGNet", "MACE"])
+def test_accepts_stubs(force_field: str):
+    calculator1 = ase_calculator("MACE")
+    calculator2 = ase_calculator(str(MLFF.MACE))
+    assert calculator1.name == calculator2.name
+
+
 def test_m3gnet_pot():
     import matgl
     from matgl.ext.ase import PESCalculator

--- a/tests/forcefields/test_utils.py
+++ b/tests/forcefields/test_utils.py
@@ -22,13 +22,6 @@ def test_raises_error():
         ase_calculator("not_a_calculator")
 
 
-@pytest.mark.parametrize(("force_field"), ["CHGNet", "MACE"])
-def test_accepts_stubs(force_field: str):
-    calculator1 = ase_calculator("MACE")
-    calculator2 = ase_calculator(str(MLFF.MACE))
-    assert calculator1.name == calculator2.name
-
-
 def test_m3gnet_pot():
     import matgl
     from matgl.ext.ase import PESCalculator


### PR DESCRIPTION
@esoteric-ephemera couple small fixes here.

I changed `return NotImplemented` -> `raise NotImplementedError` in three locations. The former fails silently.

I also added a little more flexibility around force field names. Now users can specify `force_field_name="MACE"` instead of `force_field_name="MLFF.MACE"` or `force_field_name=str(MLFF.MACE)`. 